### PR TITLE
Vnet local against flux extension

### DIFF
--- a/docs/deploy/06-aks-jumpboximage.md
+++ b/docs/deploy/06-aks-jumpboximage.md
@@ -34,7 +34,7 @@ You are going to be using Azure Image Builder to generate a Kubernetes-specific 
 
 ### Deploy the spoke
 
-1. Create the AKS jump box image builder network spoke.
+1. Create the AKS jump box image builder and JumpBox network spoke.
 
    ```bash
    RESOURCEID_VNET_HUB=$(az deployment group show -g rg-enterprise-networking-hubs -n hub-region.v0 --query properties.outputs.hubVnetId.value -o tsv)
@@ -52,8 +52,10 @@ You are going to be using Azure Image Builder to generate a Kubernetes-specific 
    ```bash
    RESOURCEID_SUBNET_AIB=$(az deployment group show -g rg-enterprise-networking-spokes -n spoke-BU0001A0005-00 --query properties.outputs.imageBuilderSubnetResourceId.value -o tsv)
 
+   RESOURCEID_SUBNET_JUMPBOX=$(az deployment group show -g rg-enterprise-networking-spokes -n spoke-BU0001A0005-00 --query properties.outputs.jumpboxSubnetResourceId.value -o tsv)
+
    # [This takes about five minutes to run.]
-   az deployment group create -g rg-enterprise-networking-hubs -f networking/hub-region.v1.bicep -p location=eastus2 aksImageBuilderSubnetResourceId="${RESOURCEID_SUBNET_AIB}"
+   az deployment group create -g rg-enterprise-networking-hubs -f networking/hub-region.v1.bicep -p location=eastus2 aksImageBuilderSubnetResourceId="${RESOURCEID_SUBNET_AIB}" aksJumpboxSubnetResourceId="${RESOURCEID_SUBNET_JUMPBOX}"
    ```
 
 ### Build and deploy the jump box image

--- a/docs/deploy/08-cluster-networking.md
+++ b/docs/deploy/08-cluster-networking.md
@@ -33,10 +33,8 @@ Your `rg-enterprise-networking-spokes` will be populated with the dedicated regi
    > :eyes: If you're curious to see what changed in the regional hub, [view the diff](https://diffviewer.azureedge.net/?l=https://raw.githubusercontent.com/mspnp/aks-baseline-regulated/main/networking/hub-region.v1.bicep&r=https://raw.githubusercontent.com/mspnp/aks-baseline-regulated/main/networking/hub-region.v2.bicep).
 
    ```bash
-   RESOURCEID_SUBNET_AIB=$(az deployment group show -g rg-enterprise-networking-spokes -n spoke-BU0001A0005-00 --query properties.outputs.imageBuilderSubnetResourceId.value -o tsv)
    RESOURCEID_SUBNET_NODEPOOLS="['$(az deployment group show -g rg-enterprise-networking-spokes -n spoke-BU0001A0005-01 --query "properties.outputs.nodepoolSubnetResourceIds.value | join ('\',\'',@)" -o tsv)']"
-   RESOURCEID_SUBNET_JUMPBOX=$(az deployment group show -g rg-enterprise-networking-spokes -n spoke-BU0001A0005-01 --query properties.outputs.jumpboxSubnetResourceId.value -o tsv)
-
+  
    # [This takes about seven minutes to run.]
    az deployment group create -g rg-enterprise-networking-hubs -f networking/hub-region.v2.bicep -p location=eastus2 aksImageBuilderSubnetResourceId="${RESOURCEID_SUBNET_AIB}" nodepoolSubnetResourceIds="${RESOURCEID_SUBNET_NODEPOOLS}" aksJumpboxSubnetResourceId="${RESOURCEID_SUBNET_JUMPBOX}"
    ```

--- a/docs/deploy/10-aks-cluster.md
+++ b/docs/deploy/10-aks-cluster.md
@@ -50,7 +50,7 @@ Now that the all the [necessary bootstrapping requirements are deployed](./09-pr
    echo GITOPS_CURRENT_BRANCH_NAME: $GITOPS_CURRENT_BRANCH_NAME
 
    # [This takes about 20 minutes to run.]
-   az deployment group create -g rg-bu0001a0005 -f cluster-stamp.bicep -p targetVnetResourceId=${RESOURCEID_VNET_CLUSTERSPOKE} clusterAdminAadGroupObjectId=${AADOBJECTID_GROUP_CLUSTERADMIN} k8sControlPlaneAuthorizationTenantId=${TENANTID_K8SRBAC} appGatewayListenerCertificate=${APP_GATEWAY_LISTENER_CERTIFICATE_BASE64} jumpBoxImageResourceId=${RESOURCEID_IMAGE_JUMPBOX} jumpBoxCloudInitAsBase64=${CLOUDINIT_BASE64} gitOpsBootstrappingRepoHttpsUrl=${GITOPS_REPOURL} gitOpsBootstrappingRepoBranch=${GITOPS_CURRENT_BRANCH_NAME}
+   az deployment group create -g rg-bu0001a0005 -f cluster-stamp.bicep -p targetVnetResourceId=${RESOURCEID_VNET_CLUSTERSPOKE} clusterAdminAadGroupObjectId=${AADOBJECTID_GROUP_CLUSTERADMIN} k8sControlPlaneAuthorizationTenantId=${TENANTID_K8SRBAC} appGatewayListenerCertificate=${APP_GATEWAY_LISTENER_CERTIFICATE_BASE64} jumpBoxImageResourceId=${RESOURCEID_IMAGE_JUMPBOX} jumpBoxCloudInitAsBase64=${CLOUDINIT_BASE64} gitOpsBootstrappingRepoHttpsUrl=${GITOPS_REPOURL} gitOpsBootstrappingRepoBranch=${GITOPS_CURRENT_BRANCH_NAME}  aksJumpboxSubnetResourceId="${RESOURCEID_SUBNET_JUMPBOX}"
 
    # Or if you updated and wish to use the parameters file …
    #az deployment group create -g rg-bu0001a0005 -f cluster-stamp.bicep -p "@azuredeploy.parameters.prod.json"

--- a/networking/hub-region.v1.bicep
+++ b/networking/hub-region.v1.bicep
@@ -6,9 +6,10 @@ targetScope = 'resourceGroup'
 @minLength(79)
 param aksImageBuilderSubnetResourceId string
 
-@description('Subnet resource Id for the AKS image builder subnet')
+@description('Subnet resource Id for the AKS jumpbox subnet')
 @minLength(79)
 param aksJumpboxSubnetResourceId string
+
 @allowed([
   'australiaeast'
   'canadacentral'

--- a/networking/hub-region.v1.bicep
+++ b/networking/hub-region.v1.bicep
@@ -504,7 +504,7 @@ resource imageBuilder_ipgroups 'Microsoft.Network/ipGroups@2021-05-01' = {
 
 @description('This holds IP addresses of known AKS Jumpbox image building subnets in attached spokes.')
 resource jumpbox_ipgroups 'Microsoft.Network/ipGroups@2021-05-01' = {
-  name: 'ipg-${location}-AksJumpbox'
+  name: 'ipg-${location}-AksJumpboxes'
   location: location
   properties: {
     ipAddresses: [

--- a/networking/hub-region.v1.bicep
+++ b/networking/hub-region.v1.bicep
@@ -6,6 +6,9 @@ targetScope = 'resourceGroup'
 @minLength(79)
 param aksImageBuilderSubnetResourceId string
 
+@description('Subnet resource Id for the AKS image builder subnet')
+@minLength(79)
+param aksJumpboxSubnetResourceId string
 @allowed([
   'australiaeast'
   'canadacentral'
@@ -68,6 +71,24 @@ resource aksSpokeVnet 'Microsoft.Network/virtualNetworks@2022-01-01' existing = 
 resource aksImageBuilderSubnet 'Microsoft.Network/virtualNetworks/subnets@2022-01-01' existing = {
   parent: aksSpokeVnet
   name: last(split(aksImageBuilderSubnetResourceId, '/'))
+}
+
+@description('The resource group name containing virtual network in which Jumpbox will be dropped.')
+resource rgJumpBoxVirutalNetwork 'Microsoft.Resources/resourceGroups@2021-04-01' existing = {
+  scope: subscription()
+  name: split(aksJumpboxSubnetResourceId, '/')[4]
+}
+
+@description('Jumpbox Spoke Virtual Network')
+resource aksJumpBoxSpokeVnet 'Microsoft.Network/virtualNetworks@2022-01-01' existing = {
+  scope: rgJumpBoxVirutalNetwork
+  name: split(aksJumpboxSubnetResourceId, '/')[8]
+}
+
+@description('Jumpbox subnet')
+resource aksJumpboxSubnet 'Microsoft.Network/virtualNetworks/subnets@2022-01-01' existing = {
+  parent: aksJumpBoxSpokeVnet
+  name: last(split(aksJumpboxSubnetResourceId, '/'))
 }
 
 resource networkWatcherResourceGroup 'Microsoft.Resources/resourceGroups@2021-04-01' existing = if (deployFlowLogResources) {
@@ -476,6 +497,17 @@ resource imageBuilder_ipgroups 'Microsoft.Network/ipGroups@2021-05-01' = {
   properties: {
     ipAddresses: [
       aksImageBuilderSubnet.properties.addressPrefix
+    ]
+  }
+}
+
+@description('This holds IP addresses of known AKS Jumpbox image building subnets in attached spokes.')
+resource jumpbox_ipgroups 'Microsoft.Network/ipGroups@2021-05-01' = {
+  name: 'ipg-${location}-AksJumpbox'
+  location: location
+  properties: {
+    ipAddresses: [
+      aksJumpboxSubnet.properties.addressPrefix
     ]
   }
 }

--- a/networking/hub-region.v2.bicep
+++ b/networking/hub-region.v2.bicep
@@ -908,6 +908,22 @@ resource hubFirewall 'Microsoft.Network/azureFirewalls@2021-05-01' = {
               ]
             }
             {
+              name: 'api-server-address'
+              description: 'Allow jumpboxes to perform kubectl.'
+              sourceIpGroups: [
+                aksJumpbox_ipgroup.id
+              ]
+              protocols: [
+                {
+                  protocolType: 'Https'
+                  port: 443
+                }
+              ]
+              targetFqdns: [
+                '*.privatelink.${location}.azmk8s.io'
+              ]
+            }
+            {
               name: 'az-management-api'
               description: 'Allow jumpboxes to communicate with Azure management APIs.'
               sourceIpGroups: [

--- a/networking/spoke-BU0001A0005-00.bicep
+++ b/networking/spoke-BU0001A0005-00.bicep
@@ -220,6 +220,146 @@ resource nsgJumpboxImgbuilderSubnet_diagnosticSettings 'Microsoft.Insights/diagn
     }
 }
 
+@description('NSG on the jumpbox image builder subnet.')
+resource nsgJumpboxSubnet 'Microsoft.Network/networkSecurityGroups@2021-05-01' = {
+    name: 'nsg-vnet-spoke-BU0001A0005-00-jumpbox'
+    location: location
+    properties: {
+        securityRules: [
+            {
+                name: 'AllowAzureLoadBalancer60001InBound'
+                properties: {
+                    description: 'Allows heath probe traffic to AIB Proxy VM on 60001 (SSH)'
+                    protocol: 'Tcp'
+                    sourcePortRange: '*'
+                    sourceAddressPrefix: 'AzureLoadBalancer'
+                    destinationPortRange: '60001'
+                    destinationAddressPrefix: 'VirtualNetwork'
+                    access: 'Allow'
+                    priority: 100
+                    direction: 'Inbound'
+                }
+            }
+            {
+                name: 'AllowVNet60001InBound'
+                properties: {
+                    description: 'Allows traffic from AIB Service PrivateLink to AIB Proxy VM'
+                    protocol: 'Tcp'
+                    sourcePortRange: '*'
+                    sourceAddressPrefix: 'VirtualNetwork'
+                    destinationPortRange: '60001'
+                    destinationAddressPrefix: 'VirtualNetwork'
+                    access: 'Allow'
+                    priority: 110
+                    direction: 'Inbound'
+                }
+            }
+            {
+                name: 'AllowVNet22InBound'
+                properties: {
+                    description: 'Allows Packer VM to receive SSH traffic from AIB Proxy VM'
+                    protocol: 'Tcp'
+                    sourcePortRange: '*'
+                    sourceAddressPrefix: 'VirtualNetwork'
+                    destinationPortRange: '22'
+                    destinationAddressPrefix: 'VirtualNetwork'
+                    access: 'Allow'
+                    priority: 120
+                    direction: 'Inbound'
+                }
+            }
+            {
+                name: 'DenyAllInBound'
+                properties: {
+                    description: 'Deny remaining traffic.'
+                    protocol: '*'
+                    sourcePortRange: '*'
+                    sourceAddressPrefix: '*'
+                    destinationPortRange: '*'
+                    destinationAddressPrefix: '*'
+                    access: 'Deny'
+                    priority: 1000
+                    direction: 'Inbound'
+                }
+            }
+            {
+                name: 'Allow443ToInternetOutBound'
+                properties: {
+                    description: 'Allow VMs to communicate to Azure management APIs, Azure Storage, and perform install tasks.'
+                    protocol: 'Tcp'
+                    sourcePortRange: '*'
+                    sourceAddressPrefix: 'VirtualNetwork'
+                    destinationPortRange: '443'
+                    destinationAddressPrefix: 'Internet'
+                    access: 'Allow'
+                    priority: 100
+                    direction: 'Outbound'
+                }
+            }
+            {
+                name: 'Allow80ToInternetOutBound'
+                properties: {
+                    description: 'Allow Packer VM to use apt-get to upgrade packages'
+                    protocol: 'Tcp'
+                    sourcePortRange: '*'
+                    sourceAddressPrefix: 'VirtualNetwork'
+                    destinationPortRange: '80'
+                    destinationAddressPrefix: 'Internet'
+                    access: 'Allow'
+                    priority: 102
+                    direction: 'Outbound'
+                }
+            }
+            {
+                name: 'AllowSshToVNetOutBound'
+                properties: {
+                    description: 'Allow Proxy VM to communicate to Packer VM'
+                    protocol: 'Tcp'
+                    sourcePortRange: '*'
+                    sourceAddressPrefix: 'VirtualNetwork'
+                    destinationPortRange: '22'
+                    destinationAddressPrefix: 'VirtualNetwork'
+                    access: 'Allow'
+                    priority: 110
+                    direction: 'Outbound'
+                }
+            }
+            {
+                name: 'DenyAllOutBound'
+                properties: {
+                    description: 'Deny all remaining outbound traffic'
+                    protocol: '*'
+                    sourcePortRange: '*'
+                    sourceAddressPrefix: '*'
+                    destinationPortRange: '*'
+                    destinationAddressPrefix: '*'
+                    access: 'Deny'
+                    priority: 1000
+                    direction: 'Outbound'
+                }
+            }
+        ]
+    }
+}
+
+resource nsgJumpboxSubnet_diagnosticSettings 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = {
+    name: 'toHub'
+    scope: nsgJumpboxSubnet
+    properties: {
+        workspaceId: hubLaWorkspace.id
+        logs: [
+            {
+                category: 'NetworkSecurityGroupEvent'
+                enabled: true
+            }
+            {
+                category: 'NetworkSecurityGroupRuleCounter'
+                enabled: true
+            }
+        ]
+    }
+}
+
 @description('This vnet is used exclusively for jumpbox image builds.')
 resource imageBuilderVNet 'Microsoft.Network/virtualNetworks@2021-05-01' = {
     name: 'vnet-spoke-BU0001A0005-00'
@@ -287,6 +427,73 @@ resource imageBuilderVNet_diagnosticSettings 'Microsoft.Insights/diagnosticSetti
     }
 }
 
+@description('This vnet is used exclusively for jumpbox vm.')
+resource jumpBoxVNet 'Microsoft.Network/virtualNetworks@2021-05-01' = {
+    name: 'vnet-spoke-BU0001A0005-01'
+    location: location
+    properties: {
+        addressSpace: {
+            addressPrefixes: [
+                '10.242.0.0/28'
+            ]
+        }
+        subnets: [
+            {
+                name: 'snet-jumpbox'
+                properties: {
+                    addressPrefix: '10.242.0.0/28'
+                    routeTable: {
+                        id: afRouteTable.id
+                    }
+                    networkSecurityGroup: {
+                        id: nsgJumpboxImgbuilderSubnet.id
+                    }
+                    privateEndpointNetworkPolicies: 'Enabled'
+                    privateLinkServiceNetworkPolicies: 'Disabled'
+                }
+            }
+        ]
+        dhcpOptions: {
+            dnsServers: [
+                hubFirewall.properties.ipConfigurations[0].properties.privateIPAddress
+            ]
+        }
+    }
+
+    resource snetJumpBox 'subnets' existing = {
+        name: 'snet-jumpbox'
+    }
+}
+
+@description('Peer to regional hub.')
+resource jumpboxVNetPeering 'Microsoft.Network/virtualNetworks/virtualNetworkPeerings@2021-05-01' = {
+    name: 'spoke-to-${last(split(hubVnetResourceId, '/'))}'
+    parent: jumpBoxVNet
+    properties: {
+        remoteVirtualNetwork: {
+            id: hubVnetResourceId
+        }
+        allowForwardedTraffic: false
+        allowVirtualNetworkAccess: true
+        allowGatewayTransit: false
+        useRemoteGateways: false
+    }
+}
+
+resource jumpBoxVNet_diagnosticSettings 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = {
+    name: 'toHub'
+    scope: jumpBoxVNet
+    properties: {
+      workspaceId: hubLaWorkspace.id
+      metrics: [
+        {
+          category: 'AllMetrics'
+          enabled: true
+        }
+      ]
+    }
+}
+
 @description('Flow Logs deployment')
 module flowlogsDeployment 'modules/flowlogsDeployment.bicep' = if (deployFlowLogResources) {
     name: 'connect-spoke-bu0001A0005-00-flowlogs'
@@ -299,8 +506,21 @@ module flowlogsDeployment 'modules/flowlogsDeployment.bicep' = if (deployFlowLog
     }
 }
 
-module hubsSpokesPeering 'modules/hubsSpokesPeeringDeployment.bicep' = {
+module hubToJjumpboxVNetPeering 'modules/hubsSpokesPeeringDeployment.bicep' = {
     name: 'hub-to-jumpboxVNet-peering'
+    scope: rgHubs
+    params: {
+      hubVNetResourceId: hubVnetResourceId
+      spokesVNetName: jumpBoxVNet.name
+      rgSpokes: resourceGroup().name
+    }
+    dependsOn: [
+        jumpboxVNetPeering
+    ]
+}
+
+module hubToImageBuilderVNetPeering 'modules/hubsSpokesPeeringDeployment.bicep' = {
+    name: 'hub-to-imageBuilderVNet-peering'
     scope: rgHubs
     params: {
       hubVNetResourceId: hubVnetResourceId
@@ -315,3 +535,4 @@ module hubsSpokesPeering 'modules/hubsSpokesPeeringDeployment.bicep' = {
 /*** OUTPUTS ***/
 
 output imageBuilderSubnetResourceId string = imageBuilderVNet::snetImageBuilder.id
+output jumpBoxSubnetResourceId string = jumpBoxVNet::snetJumpBox.id

--- a/networking/spoke-BU0001A0005-00.bicep
+++ b/networking/spoke-BU0001A0005-00.bicep
@@ -535,4 +535,4 @@ module hubToImageBuilderVNetPeering 'modules/hubsSpokesPeeringDeployment.bicep' 
 /*** OUTPUTS ***/
 
 output imageBuilderSubnetResourceId string = imageBuilderVNet::snetImageBuilder.id
-output jumpBoxSubnetResourceId string = jumpBoxVNet::snetJumpBox.id
+output jumpboxSubnetResourceId string = jumpBoxVNet::snetJumpBox.id

--- a/networking/spoke-BU0001A0005-01.bicep
+++ b/networking/spoke-BU0001A0005-01.bicep
@@ -608,7 +608,7 @@ resource nsgAcrDockerSubnet_diagnosticSettings 'Microsoft.Insights/diagnosticSet
 
 @description('cluster\'s virtual network. 65,536 (-reserved) IPs available to the workload, split across four subnets for AKS, one for App Gateway, and two for management.')
 resource clusterVNet 'Microsoft.Network/virtualNetworks@2021-05-01' = {
-    name: 'vnet-spoke-${orgAppId}-01'
+    name: 'vnet-spoke-${orgAppId}-02'
     location: location
     properties: {
         addressSpace: {
@@ -769,7 +769,7 @@ resource clusterVNet 'Microsoft.Network/virtualNetworks@2021-05-01' = {
 module policyAssignmentNoPublicIpsInVnet './modules/ClusterVNetShouldNotHaveNICwithpublicIP.bicep' = {
     name: 'Apply-Subscription-Spoke-PipUsage-Policies-01'
     params: {
-        clusterVNetId: resourceId('Microsoft.Network/virtualNetworks','vnet-spoke-${orgAppId}-01')
+        clusterVNetId: resourceId('Microsoft.Network/virtualNetworks','vnet-spoke-${orgAppId}-02')
     }
 }
 

--- a/networking/spoke-BU0001A0005-01.bicep
+++ b/networking/spoke-BU0001A0005-01.bicep
@@ -98,7 +98,7 @@ resource afRouteTable 'Microsoft.Network/routeTables@2021-05-01' = {
 
 @description('NSG blocking all inbound traffic other than port 22 for jumpbox access.')
 resource nsgAllowSshFromHubBastionInBound 'Microsoft.Network/networkSecurityGroups@2021-05-01' = {
-    name: 'nsg-vnet-spoke-${orgAppId}-01-management-ops'
+    name: 'nsg-vnet-spoke-${orgAppId}-02-management-ops'
     location: location
     properties: {
         securityRules: [
@@ -193,7 +193,7 @@ resource nsgAllowSshFromHubBastionInBound_diagnosticSettings 'Microsoft.Insights
 
 @description('NSG on all AKS system nodepools. Feel free to constrict further both inbound and outbound!')
 resource nsgAksSystemNodepools 'Microsoft.Network/networkSecurityGroups@2021-05-01' = {
-    name: 'nsg-vnet-spoke-${orgAppId}-01-system-nodepools'
+    name: 'nsg-vnet-spoke-${orgAppId}-02-system-nodepools'
     location: location
     properties: {
         securityRules: [
@@ -235,7 +235,7 @@ resource nsgAksSystemNodepools_diagnosticSettings 'Microsoft.Insights/diagnostic
 
 @description('NSG on the AKS in-scope nodepools. Feel free to constrict further both inbound and outbound!')
 resource nsgAksInScopeNodepools 'Microsoft.Network/networkSecurityGroups@2021-05-01' = {
-    name: 'nsg-vnet-spoke-${orgAppId}-01-is-nodepools'
+    name: 'nsg-vnet-spoke-${orgAppId}-02-is-nodepools'
     location: location
     properties: {
         securityRules: [
@@ -277,7 +277,7 @@ resource nsgAksInScopeNodepools_diagnosticSettings 'Microsoft.Insights/diagnosti
 
 @description('NSG on the AKS out-of-scope nodepools. Feel free to constrict further both inbound and outbound!')
 resource nsgAksOutOfScopeNodepools 'Microsoft.Network/networkSecurityGroups@2021-05-01' = {
-    name: 'nsg-vnet-spoke-${orgAppId}-01-oos-nodepools'
+    name: 'nsg-vnet-spoke-${orgAppId}-02-oos-nodepools'
     location: location
     properties: {
         securityRules: [
@@ -319,7 +319,7 @@ resource nsgAksOutOfScopeNodepools_diagnosticSettings 'Microsoft.Insights/diagno
 
 @description('Default NSG on the private link subnet. No traffic should be allowed out, and only Tcp/443 in. Key Vault and Container Registry is expected to be accessed in here.')
 resource nsgAksPrivateLinkEndpoint 'Microsoft.Network/networkSecurityGroups@2021-05-01' = {
-    name: 'nsg-vnet-spoke-${orgAppId}-01-privatelinkendpoints'
+    name: 'nsg-vnet-spoke-${orgAppId}-02-privatelinkendpoints'
     location: location
     properties: {
         securityRules: [
@@ -386,7 +386,7 @@ resource nsgAksPrivateLinkEndpoint_diagnosticSettings 'Microsoft.Insights/diagno
 
 @description('Default NSG on the AKS ILB subnet. Feel free to constrict further!')
 resource nsgAksDefaultILBSubnet 'Microsoft.Network/networkSecurityGroups@2021-05-01' = {
-    name: 'nsg-vnet-spoke-${orgAppId}-01-akslibs'
+    name: 'nsg-vnet-spoke-${orgAppId}-02-akslibs'
     location: location
     properties: {
         securityRules: [
@@ -414,7 +414,7 @@ resource nsgAksDefaultILBSubnet_diagnosticSettings 'Microsoft.Insights/diagnosti
 
 @description('NSG on the App Gateway subnet.')
 resource nsgAppGatewaySubnet 'Microsoft.Network/networkSecurityGroups@2021-05-01' = {
-    name: 'nsg-vnet-spoke-${orgAppId}-01-appgw'
+    name: 'nsg-vnet-spoke-${orgAppId}-02-appgw'
     location: location
     properties: {
         securityRules: [
@@ -510,7 +510,7 @@ resource nsgAppGatewaySubnet_diagnosticSettings 'Microsoft.Insights/diagnosticSe
 
 @description('NSG on the ACR docker subnet.')
 resource nsgAcrDockerSubnet 'Microsoft.Network/networkSecurityGroups@2021-05-01' = {
-    name: 'nsg-vnet-spoke-${orgAppId}-01-acragents'
+    name: 'nsg-vnet-spoke-${orgAppId}-02-acragents'
     location: location
     properties: {
         securityRules: [

--- a/networking/spoke-BU0001A0005-01.bicep
+++ b/networking/spoke-BU0001A0005-01.bicep
@@ -682,20 +682,6 @@ resource clusterVNet 'Microsoft.Network/virtualNetworks@2021-05-01' = {
                 }
             }
             {
-                name: 'snet-management-ops'
-                properties: {
-                    addressPrefix: '10.240.1.0/28'
-                    routeTable: {
-                        id: afRouteTable.id
-                    }
-                    networkSecurityGroup: {
-                        id: nsgAllowSshFromHubBastionInBound.id
-                    }
-                    privateEndpointNetworkPolicies: 'Disabled'
-                    privateLinkServiceNetworkPolicies: 'Disabled'
-                }
-            }
-            {
                 name: 'snet-management-agents'
                 properties: {
                     addressPrefix: '10.240.2.0/26'
@@ -758,10 +744,6 @@ resource clusterVNet 'Microsoft.Network/virtualNetworks@2021-05-01' = {
 
     resource aksSystemOutOfScopeNodepoolsSubnet 'subnets' existing = {
         name: 'snet-cluster-outofscopenodepools'
-    }
-
-    resource aksManagementOpsSubnet 'subnets' existing = {
-        name: 'snet-management-ops'
     }
 }
 
@@ -1011,8 +993,6 @@ module flowlogsDeploymentAksSystemNodepools 'modules/flowlogsDeployment.bicep' =
 /*** OUTPUTS ***/
 
 output clusterVnetResourceId string = clusterVNet.id
-
-output jumpboxSubnetResourceId string = clusterVNet::aksManagementOpsSubnet.id
 
 output nodepoolSubnetResourceIds array = [
     clusterVNet::aksSystemNodepoolSubnet.id


### PR DESCRIPTION
I was working on the vnet-jumbox ticket.
The goods. There is a PR (local in my fork https://github.com/v-fearam/aks-baseline-regulated/pull/1) on top of flux-extension (it must be merged before) which:
*  There is a new vnet for Jumbox
* The vnet is a new spoke in the same region
* The Jumpbox is on the new vnet
* We are able to operate from that vnet 
           
The bads. It was not able to create a private link/dns on the new vnet to access the cluster api. The current design use  the FireWall as proxy DNS. There is a private dns on the hub vnet which resolve the current private ip for the cluster api. 
Maintaining that design I’m not able to create a second private DNS against the same cluster api to resolve another private ip (the private endpoint in the new vnet). In the current design it must be on the hub vnet entering in conflict with the current one.  
Now the traffic is allowed to move from the new Jumpbox vnet to the firewall, allowed in the firewall , and then moved to the cluster vnet private ip to access the cluster api.   
The main image was not changed.
